### PR TITLE
Removed needv8update tag from 404handler.config

### DIFF
--- a/Reference/Config/404handlers/index.md
+++ b/Reference/Config/404handlers/index.md
@@ -1,6 +1,5 @@
 ---
 versionFrom: 7.0.0
-needsV8Update: "true"
 ---
 
 # 404handlers.config


### PR DESCRIPTION
The `404handlers.config` is obsolete. So it does not need v8 update and hence the tag can be removed